### PR TITLE
Use german verb instead of noun for post

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -1,5 +1,4 @@
 {
-  "post": "beitragen",
   "remove_post": "Beitrag löschen",
   "no_posts": "Keine Beiträge.",
   "create_a_post": "Erstelle einen Beitrag",
@@ -25,6 +24,7 @@
   "number_of_communities": "{{formattedCount}} Community",
   "number_of_communities_plural": "{{formattedCount}} Communitys",
   "community_reqs": "Kleinbuchstaben, Großbuchstaben und keine Leerzeichen.",
+  "post": "beitragen",
   "edit": "editieren",
   "reply": "antworten",
   "cancel": "Abbrechen",

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,5 +1,5 @@
 {
-  "post": "Beitrag",
+  "post": "beitragen",
   "remove_post": "Beitrag löschen",
   "no_posts": "Keine Beiträge.",
   "create_a_post": "Erstelle einen Beitrag",


### PR DESCRIPTION
Hi everyone,

I just wanted to post my first message and notices that the german translation for posting is not correct.

The german noun for post is Beitrag, the verb though is beitragen. The usage of the noun therefore makes no sense beneath the textfield. See the attached screenshot.

Hope that helps.

