### PR TITLE
Remove stray comma from verify_email_body

### DIFF
--- a/email/en.json
+++ b/email/en.json
@@ -6,7 +6,7 @@
   "password_reset_subject": "Password reset for {username}",
   "password_reset_body": "<h1>Password Reset Request for {username}</h1><br><a href=\"{reset_link}\">Click here to reset your password</a>",
   "verify_email_subject": "Verify your email address for {hostname}",
-  "verify_email_body": "Please click the link below to verify your email address for the account @{username}@{hostname}. Ignore this email if the account isn't yours.<br><br>, <a href=\"{verify_link}\">Verify your email</a>",
+  "verify_email_body": "Please click the link below to verify your email address for the account @{username}@{hostname}. Ignore this email if the account isn't yours.<br><br><a href=\"{verify_link}\">Verify your email</a>",
   "email_verified_subject": "Email verified for {username}",
   "email_verified_body": "Your email has been verified.",
   "notification_post_reply_subject": "Reply from {username}",


### PR DESCRIPTION
There is an unnecessary comma in the e-mail verification message body:

![Screenshot 2023-06-10 at 21 51 39](https://github.com/LemmyNet/lemmy-translations/assets/5356547/23bc7328-69d2-4de0-97e9-f2868455490f)

This PR removes the comma.

Note that this comma also appears in several translated strings, but I am assuming that the `en.json` file is the original source of all translations, and other strings should be fixed in Weblate. Please correct me if I'm wrong!