### PR TITLE
Remove prettier from CI

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,8 +1,4 @@
 pipeline:
-  prettier_markdown_check:
-    image: tmknom/prettier
-    commands:
-      - prettier -c .
 
   notify_on_failure:
     image: alpine:3


### PR DESCRIPTION
Weblate doesnt apply proper formatting when pushing changes, so we would have to fix it manually all the time.