### PR TITLE
Remove e-mail verified source strings

### DIFF
--- a/email/en.json
+++ b/email/en.json
@@ -10,8 +10,6 @@
   "password_reset_body": "<h1>Password Reset Request for {username}</h1><br><a href=\"{reset_link}\">Click here to reset your password</a>",
   "verify_email_subject": "Verify your email address for {hostname}",
   "verify_email_body": "Please click the link below to verify your email address for the account @{username}@{hostname}. Ignore this email if the account isn't yours.<br><br>, <a href=\"{verify_link}\">Verify your email</a>",
-  "email_verified_subject": "Email verified for {username}",
-  "email_verified_body": "Your email has been verified.",
   "notification_post_reply_subject": "Reply from {username}",
   "notification_post_reply_body": "<h1>Post reply</h1><br><div>{username} - {comment_text}</div><br><a href=\"{inbox_link}\">inbox</a>",
   "notification_comment_reply_subject": "Reply from {username}",


### PR DESCRIPTION
This PR removes the source strings for the "e-mail verified" e-mails, as these would be unnecessary after https://github.com/LemmyNet/lemmy/pull/3124