### PR TITLE
Incorrect_Login String

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -510,5 +510,6 @@
   "add_instance": "Add instance",
   "open_links_in_new_tab": "Open links in a new tab",
   "op": "OP",
-  "couldnt_create_audio_captcha": "Couldn't create audio captcha."
+  "couldnt_create_audio_captcha": "Couldn't create audio captcha.",
+  "incorrect_login": "Incorrect login credentials"
 }


### PR DESCRIPTION
I'm working on https://github.com/LemmyNet/lemmy-ui/pull/1874 right now, but there's a concern informing users of wrong passwords can be an attack vector. This PR amends this by adding a generic "incorrect_login" string to `lemmy-translations`.