### PR TITLE
Clarify 2FA instructions (en)

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -501,7 +501,7 @@
   "set_up_two_factor": "Set up 2-factor authentication",
   "enter_two_factor_code": "Enter your 2FA code",
   "two_factor_link": "2FA installation link",
-  "two_factor_setup_instructions": "Click save, then manually reload this page, scroll down and use the '2FA installation link' to obtain the oauth URL for your authenticator.",
+  "two_factor_setup_instructions": "Click 'Save', then manually reload this page, scroll down and use the '2FA installation link' to obtain the oauth URL for your authenticator.",
   "remove_two_factor": "Remove 2-factor authentication",
   "two_factor_token": "2FA Token",
   "jump_to_content": "Jump to content",

--- a/translations/en.json
+++ b/translations/en.json
@@ -501,7 +501,7 @@
   "set_up_two_factor": "Set up 2-factor authentication",
   "enter_two_factor_code": "Enter your 2FA code",
   "two_factor_link": "2FA installation link",
-  "two_factor_setup_instructions": "After you click save, and the page reloads, scroll down and click '2FA installation link' to add it to your authenticator.",
+  "two_factor_setup_instructions": "Click save, then manually reload this page, scroll down and use the '2FA installation link' to obtain the oauth URL for your authenticator.",
   "remove_two_factor": "Remove 2-factor authentication",
   "two_factor_token": "2FA Token",
   "jump_to_content": "Jump to content",


### PR DESCRIPTION
The existing instructions suggest that saving setting with 2FA enabled will cause a link to appear, which is not the case. When 2FA is enabled and the user is logged out, they are locked out as there is no 2FA code to provide at login. This creates a significant burden on the user and administrator to re-enable access.

These revised instructions include the necessary manual reload of the page and specification of the oath URL (as many folks will be used to QR codes and strings).