### PR TITLE
Make invalid password message less redundant

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -297,7 +297,7 @@
   "password": "Password",
   "change_password": "Change Password",
   "password_changed": "Password Changed.",
-  "invalid_password": "Invalid password. Password length must be between 10 and 60 characters.",
+  "invalid_password": "Password length must be between 10 and 60 characters.",
   "verify_password": "Verify Password",
   "old_password": "Old Password",
   "forgot_password": "forgot password",


### PR DESCRIPTION
Looking at the screenshot from the [password length PR that was merged recently](https://github.com/LemmyNet/lemmy-ui/pull/2364), the message was pretty redundant. This takes away some of the redundancy.