### PR TITLE
Fix params for error_page_paragraph

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -292,7 +292,7 @@
   "sign_up": "Sign Up",
   "notifications_error": "Desktop notifications not available in your browser. Try Firefox or Chrome.",
   "error_page_title": "Error!",
-  "error_page_paragraph": "There was an error on the server. Try refreshing your browser. If that doesn't work, come back at a later time. If the problem persists, you can seek help in the <1>Lemmy support community</1> or <1>Lemmy Matrix room</1>.",
+  "error_page_paragraph": "There was an error on the server. Try refreshing your browser. If that doesn't work, come back at a later time. If the problem persists, you can seek help in the <1>Lemmy support community</1> or <2>Lemmy Matrix room</2>.",
   "error_page_admin_matrix": "If you would like to reach out to one of {{instance}} admins for support, try the following Matrix addresses:",
   "error_code_message": "The server returned this error: <1>{{error}}</1>. This may be useful for admins and developers to diagnose and fix the error",
   "not_found_page_title": "Page Not Found",


### PR DESCRIPTION
This is probably the reason why the same link is shown twice. See
- https://github.com/LemmyNet/lemmy-ui/issues/1561
- https://lemmy.ml/u/asdwasd