### PR TITLE
Change wording to clarify the security of private messages

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -324,7 +324,7 @@
   "email": "Email",
   "matrix_user_id": "Matrix User",
   "invalid_matrix_id": "Invalid matrix id. Must be @user:instance.tld",
-  "private_message_disclaimer": "Warning: Private messages in Lemmy are not secure. Please create an account on <1>Matrix</1> for secure messaging.",
+  "private_message_disclaimer": "Warning: Private messages in Lemmy are not End-to-End encrypted, so the respective instance owners are technically able to read them. Please use a platform with E2E encryption for private messaging. Lemmy recommends <1>Matrix</1> and XMPP.",
   "send_notifications_to_email": "Send notifications to Email",
   "optional": "Optional",
   "expires": "Expires",


### PR DESCRIPTION
This commit follows a (brief) discussion in Lemmy here: https://lemmy.ml/post/35286160

A note outside of the commit message. I wasn't sure how heavy is Lemmy in recommending Matrix specifically, so I tried choosing a wording that addresses the core issue: End-to-End encryption, and then adding specific recommendations in a separate sentence later.

The main idea behind this change is to be explicit about what it even means to be "secure" or "not secure" in the context of Lemmy.