### PR TITLE
Update incorrect translations for cross_posted_from_url

### DIFF
--- a/translations/bg.json
+++ b/translations/bg.json
@@ -746,7 +746,7 @@
     "show_user_vote_totals": "Показване на общо глас. за потребителя",
     "lock_post": "Заключване на публикацията",
     "unlock_post": "Отключване на публикацията",
-    "cross_posted_from_url": "препубликувано от: {{- ap_id}}",
+    "cross_posted_from_url": "препубликувано от: {{ap_id}}",
     "lock_comment": "Заключване на коментара",
     "unlock_comment": "Отключване на коментара",
     "one_hour": "Един час",

--- a/translations/bs.json
+++ b/translations/bs.json
@@ -17,7 +17,7 @@
     "cross_posts": "Ova poveznica je također objavljena na:",
     "cross_post": "Unakrsna objava",
     "cross_posted_to": "unakrsno objavljeno na: ",
-    "cross_posted_from_url": "unakrsno objavljeno sa: {{- ap_id}}",
+    "cross_posted_from_url": "unakrsno objavljeno sa: {{ap_id}}",
     "share_post": "Podijeli objavu",
     "comments": "Komentari",
     "number_of_comments": "{{formattedCount}} Komentar",

--- a/translations/ca.json
+++ b/translations/ca.json
@@ -748,7 +748,7 @@
     "notification_mode_all_posts_and_comments": "Totes les publicacions i comentaris",
     "lock_post": "Bloquejar publicació",
     "unlock_post": "Desbloquejar publicació",
-    "cross_posted_from_url": "publicació creuada de: {{- ap_id}}",
+    "cross_posted_from_url": "publicació creuada de: {{ap_id}}",
     "language_browser_default": "Predeterminada del navegador",
     "post_time_range": "Mostrar publicacions des de l'última",
     "banned_dialog_body": "No podeu publicar, votar ni dur a terme altres accions. Tanmateix, podeu continuar navegant pel lloc i, a la pàgina de configuració, exportar la configuració per importar-la en una altra instància de Lemmy, crear una còpia de seguretat o eliminar el compte.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -17,7 +17,7 @@
   "cross_posts": "This link has also been posted to:",
   "cross_post": "Cross-post",
   "cross_posted_to": "cross-posted to: ",
-  "cross_posted_from_url": "cross-posted from: {{- ap_id}}",
+  "cross_posted_from_url": "cross-posted from: {{ap_id}}",
   "share_post": "Share post",
   "comments": "Comments",
   "number_of_comments": "{{formattedCount}} Comment",

--- a/translations/hr.json
+++ b/translations/hr.json
@@ -17,7 +17,7 @@
     "cross_posts": "Ova poveznica je također objavljena na:",
     "cross_post": "Unakrsna objava",
     "cross_posted_to": "unakrsno objavljeno na: ",
-    "cross_posted_from_url": "unakrsno objavljeno s: {{- ap_id}}",
+    "cross_posted_from_url": "unakrsno objavljeno s: {{ap_id}}",
     "share_post": "Dijeli objavu",
     "comments": "Komentari",
     "number_of_comments": "{{formattedCount}} Komentar",

--- a/translations/mk.json
+++ b/translations/mk.json
@@ -17,7 +17,7 @@
     "cross_posts": "Оваа врска е објавена и на:",
     "cross_post": "Вкрстена објава",
     "cross_posted_to": "вкрстена објава до: ",
-    "cross_posted_from_url": "вкрстена објава од: {{- ap_id}}",
+    "cross_posted_from_url": "вкрстена објава од: {{ap_id}}",
     "share_post": "Сподели објава",
     "comments": "Коментари",
     "number_of_comments": "{{formattedCount}} Коментар",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -674,7 +674,7 @@
     "unlock_post": "Bericht ontgrendelen",
     "report_community": "Gemeenschap rapporteren",
     "post_time_range": "Berichten tonen van laatste",
-    "cross_posted_from_url": "als kruisbericht geplaatst vanuit {{- ap_id}}",
+    "cross_posted_from_url": "als kruisbericht geplaatst vanuit {{ap_id}}",
     "lock_comment": "Opmerking vergrendelen",
     "unlock_comment": "Opmerking ontgrendelen",
     "locking": "Bezig met vergrendelen",

--- a/translations/sl.json
+++ b/translations/sl.json
@@ -17,7 +17,7 @@
     "cross_posts": "Ta povezava je bila objavljena tudi v:",
     "cross_post": "Navzkrižna objava",
     "cross_posted_to": "navzkrižno objavljeno v: ",
-    "cross_posted_from_url": "navzkrižno objavljeno iz: {{- ap_id}}",
+    "cross_posted_from_url": "navzkrižno objavljeno iz: {{ap_id}}",
     "share_post": "Deli objavo",
     "comments": "Komentarji",
     "number_of_comments": "{{formattedCount}} Komentar",

--- a/translations/sq.json
+++ b/translations/sq.json
@@ -17,7 +17,7 @@
     "cross_posts": "Kjo lidhje është postuar edhe në:",
     "cross_post": "Kryq-postim",
     "cross_posted_to": "kryq-postuar në: ",
-    "cross_posted_from_url": "kryq-postuar nga: {{- ap_id}}",
+    "cross_posted_from_url": "kryq-postuar nga: {{ap_id}}",
     "share_post": "Shpërnda postimin",
     "comments": "Komente",
     "number_of_comments": "{{formattedCount}} Koment",

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -740,7 +740,7 @@
     "show_community_reports": "显示社区举报",
     "lock_post": "锁定帖子",
     "unlock_post": "帖子锁定解除",
-    "cross_posted_from_url": "跨站发布自：{{- ap_id}}",
+    "cross_posted_from_url": "跨站发布自：{{ap_id}}",
     "lock_comment": "锁定评论",
     "unlock_comment": "评论锁定解除",
     "visit_random_community": "随机访问一个社区",

--- a/translations/zh_Hant.json
+++ b/translations/zh_Hant.json
@@ -732,7 +732,7 @@
     "show_community_reports": "顯示社群報告",
     "lock_post": "鎖定貼文",
     "unlock_post": "解除鎖定貼文",
-    "cross_posted_from_url": "跨站張貼自：{{- ap_id}}",
+    "cross_posted_from_url": "跨站張貼自：{{ap_id}}",
     "unlock_comment": "解除鎖定留言",
     "locking": "鎖定中",
     "unlocking": "正在解除鎖定",


### PR DESCRIPTION
Resolves a TypeScript syntax error when building lemmy-ui. It looks like the i18next types are generated based on the English file, and that's one of a small number of files which has this syntax error in the substitution.